### PR TITLE
Modify: supplement the kornia version of requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ opencv-python
 pyquaternion
 spconv-cu113
 av2
-kornia
+kornia==0.6.9
 torch_scatter
 shapely==1.8.4


### PR DESCRIPTION
About Issue #22 
```
After February 2023 kornia is phasing out jit support for some functions.
see link
If a jit error occurs anywhere, it is probably caused here.

Solution: pip install kornia==0.6.9
```